### PR TITLE
[docs] Fix on the installation instructions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,7 +39,7 @@ run:
 
 ```julia
 using Pkg
-Pkg.add("https://github.com/jump-dev/ModelAnalyzer.jl")
+Pkg.add(url = "https://github.com/jump-dev/ModelAnalyzer.jl")
 ```
 
 ## Usage


### PR DESCRIPTION
Minor fix on the docs to avoid the following error:

```julia
ERROR: `https://github.com/jump-dev/ModelAnalyzer.jl` is not a valid package name. Perhaps you meant `https://github.com/jump-dev/ModelAnalyzer`
The argument appears to be a URL or path, perhaps you meant `Pkg.add(url="...")` or `Pkg.add(path="...")`.
```